### PR TITLE
Scope trame stack to full environment

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,19 @@
+# Copilot Usage Guidance for SCEPTer
+
+## Project context
+SCEPTer simulates satellite constellation emissions and the resulting EPFD for radio telescopes. It relies on Python 3.10, PyCRAF, and cysgp4, and is typically exercised through notebooks and the `scepter` Python package.
+
+## Coding preferences
+- Use Python type hints in new or updated code.
+- Follow standard library-first imports: standard library, third-party, then local modules.
+- Prefer explicit, readable variable names; avoid single-letter names outside of short loops.
+- Keep docstrings concise with a one-line summary plus argument/return descriptions when applicable.
+- Favor immutable inputs where possible and avoid in-place mutation unless necessary for performance.
+
+## Testing and notebooks
+- Where feasible, add or update lightweight tests that illustrate expected behavior for new functions.
+- For notebooks, keep cells focused and prefer markdown explanations alongside code so Copilot can suggest context-aware completions.
+
+## Conversation hints
+- When Copilot Chat is asked for changes, summarize the intent and list the files it plans to touch before proposing edits.
+- If unsure about domain-specific terms (e.g., EPFD), prompt for clarification before generating code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent Guidelines for SCEPTer
+
+These instructions apply to the entire repository.
+
+- Read `.github/copilot-instructions.md` before suggesting structural or code changes so AI helpers align with project preferences.
+- Keep dependency updates consistent: adjust both `environment.yml` (lite) and `environment-full.yml` (full) when packages change, and refresh the README's development environment section if commands or options shift.
+- Stick to Python 3.10-compatible solutions. Place heavy GPU/visualization extras in the full environment unless they are strictly required in the lite setup.
+- When editing documentation or notebooks, keep environment commands copy/paste-ready and refer to the environments as `scepter-dev` (lite) and `scepter-dev-full` (full).
+- Run targeted tests or illustrative notebooks when modifying simulation pipelines, and note any intentional skips with context in the final summary.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,24 @@ Satellite TLEs can be found on https://celestrak.org/
 
 We use the PyCRAF and cysgp4 packages for many of the base calculations, see requirements.txt for list of dependancies, code was written and tested in Python 3.10
 
+## Development environment
+
+Two Conda environment files are provided so you can choose between a lighter install and the fully accelerated/visualization stack:
+
+- **Lite (default)** – core dependencies only, quickest to create: `conda env create -f environment.yml && conda activate scepter-dev`
+- **Full** – includes optional GPU acceleration and visualization packages (`numba`, `cuda-version>=12.0`, `pyvista`, `plotly`, `python-kaleido`, `trame`, `trame-jupyter-extension`, `jupyter-server-proxy`, `trame-vtk`, `trame-vuetify`): `conda env create -f environment-full.yml && conda activate scepter-dev-full`
+
+If you start with the lite environment and later need the optional packages, update it in place with:
+
+```bash
+conda env update -n scepter-dev -f environment-full.yml
+python -m ipykernel install --user --name scepter-dev
+```
+
+All packages are pulled from `conda-forge`, including CUDA-enabled builds where available, so Codespaces or local shells using either environment will align with the expected toolchain.
+
+GitHub Copilot users can refer to `.github/copilot-instructions.md` for project-specific guidance to keep suggestions consistent with the codebase. Agents and collaborators can consult `AGENTS.md` for repository-wide instructions on environment updates and testing expectations.
+
 ### Simulation Example Figure
 
 ![Simulation Grid](./notebooks/example.png)

--- a/environment-full.yml
+++ b/environment-full.yml
@@ -1,0 +1,25 @@
+name: scepter-dev-full
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - conda-build
+  - cysgp4
+  - pycraf
+  - ipykernel
+  - "ipywidgets>=7.0,<8.0"
+  - tqdm
+  - seaborn
+  - ipympl
+  # Optional visualization stack
+  - trame
+  - trame-jupyter-extension
+  - jupyter-server-proxy
+  - trame-vtk
+  - trame-vuetify
+  # Optional accelerators and GPU-enabled visualization support
+  - numba
+  - "cuda-version>=12.0"
+  - pyvista
+  - plotly
+  - python-kaleido

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,13 @@
+name: scepter-dev
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - conda-build
+  - cysgp4
+  - pycraf
+  - ipykernel
+  - "ipywidgets>=7.0,<8.0"
+  - tqdm
+  - seaborn
+  - ipympl


### PR DESCRIPTION
## Summary
- remove trame-based visualization dependencies from the lite Conda environment
- keep the trame/pyvista visualization stack grouped in the full environment definition
- document the full environment optional package list in the README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943b90f20e4832e9da0181c141e4a44)